### PR TITLE
EPROD-421 used generic expressions in virtual_canister_call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "4824fd1
 ic-types = { git = "https://github.com/dfinity/ic", rev = "4824fd13586f1be43ea842241f22ee98f98230d0" }
 icp-ledger = { git = "https://github.com/dfinity/ic", rev = "4824fd13586f1be43ea842241f22ee98f98230d0" }
 icrc-ledger-types = { git = "https://github.com/dfinity/ic", rev = "4824fd13586f1be43ea842241f22ee98f98230d0" }
-ic-kit = { git = "https://github.com/infinity-swap/ic-kit", tag = "v0.4.9" }
+ic-kit = { git = "https://github.com/infinity-swap/ic-kit", tag = "v0.4.10" }
 ledger-canister = { git = "https://github.com/dfinity/ic", rev = "4824fd13586f1be43ea842241f22ee98f98230d0" }
 ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "4824fd13586f1be43ea842241f22ee98f98230d0" }
 ic-ledger-canister-core = { git = "https://github.com/dfinity/ic", rev = "4824fd13586f1be43ea842241f22ee98f98230d0" }


### PR DESCRIPTION
To call the vitual_canister_call macro from other utility functions, the method name and arguments type was changed to generic expressions.