### PR TITLE
Add reserved length setting

### DIFF
--- a/ic-stable-structures/src/memory_mapped_files/memory_mapped_file.rs
+++ b/ic-stable-structures/src/memory_mapped_files/memory_mapped_file.rs
@@ -263,7 +263,7 @@ mod tests {
     #[test]
     fn should_expand() {
         with_temp_file(|path| {
-            let mut file_memory = MemoryMappedFile::new(path, PAGE_SIZE, true).unwrap();
+            let mut file_memory = MemoryMappedFile::new(path, PAGE_SIZE * 5, true).unwrap();
             file_memory.resize(PAGE_SIZE).unwrap();
             assert_eq!(file_memory.len(), PAGE_SIZE);
 
@@ -288,6 +288,19 @@ mod tests {
                 slice,
                 &[[42; PAGE_SIZE as _], [43; PAGE_SIZE as _]].concat()[..]
             )
+        })
+    }
+
+    #[test]
+    fn should_check_reserved_address_length() {
+        with_temp_file(|path| {
+            let reserved_size = PAGE_SIZE * 5;
+            let mut file_memory = MemoryMappedFile::new(path, reserved_size, true).unwrap();
+            let claimed_size = PAGE_SIZE * 6;
+            let result = file_memory.resize(claimed_size).unwrap_err();
+            assert!(
+                matches!(result, MemMapError::OutOfAddressSpace { claimed, limit } if claimed == claimed_size && limit == reserved_size)
+            );
         })
     }
 

--- a/ic-stable-structures/tests/memory_mapped_files/mod.rs
+++ b/ic-stable-structures/tests/memory_mapped_files/mod.rs
@@ -7,7 +7,7 @@ use ic_stable_structures::{
 use parking_lot::Mutex;
 use tempfile::{NamedTempFile, TempDir};
 
-const RESERVED_LENGTH: u64 = 64 * 1024;
+const RESERVED_LENGTH: u64 = 1024 * 1024 * 1024;
 
 #[test]
 fn test_persistent_memory_mapped_file_memory() {

--- a/ic-stable-structures/tests/memory_mapped_files/mod.rs
+++ b/ic-stable-structures/tests/memory_mapped_files/mod.rs
@@ -7,11 +7,17 @@ use ic_stable_structures::{
 use parking_lot::Mutex;
 use tempfile::{NamedTempFile, TempDir};
 
+const RESERVED_LENGTH: u64 = 64 * 1024;
+
 #[test]
 fn test_persistent_memory_mapped_file_memory() {
     let file = NamedTempFile::new().unwrap();
-    let memory_resource =
-        MemoryMappedFileMemory::new(file.path().to_str().unwrap().to_owned(), true).unwrap();
+    let memory_resource = MemoryMappedFileMemory::new(
+        file.path().to_str().unwrap().to_owned(),
+        RESERVED_LENGTH,
+        true,
+    )
+    .unwrap();
     let memory_manager = IcMemoryManager::init(memory_resource);
 
     let mut vec = StableVec::<u32, _>::new(memory_manager.get(MemoryId::new(0))).unwrap();
@@ -25,8 +31,12 @@ fn test_persistent_memory_mapped_file_memory() {
     map.insert(4, 5);
     drop(memory_manager);
 
-    let memory_resource =
-        MemoryMappedFileMemory::new(file.path().to_str().unwrap().to_owned(), true).unwrap();
+    let memory_resource = MemoryMappedFileMemory::new(
+        file.path().to_str().unwrap().to_owned(),
+        RESERVED_LENGTH,
+        true,
+    )
+    .unwrap();
     let memory_manager = IcMemoryManager::init(memory_resource);
 
     let vec = StableVec::<u32, _>::new(memory_manager.get(MemoryId::new(0))).unwrap();


### PR DESCRIPTION
Before we were reserving 1 TB of virtual memory space for each memory-mapped file. Which is OK for a single x64 application which has 2^48/2 = 128 TB user address space. But if we are running EVMC tests concurrently where several dozens of files are created for each state we may end up getting memory allocation error (which is actually address space allocation error).
That's why I've added a possibility to change the default reserved length, now it is used in tests only. 