### PR TITLE
Fix: `getrandom` dependency issue in WASM build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 
 [workspace.dependencies]
@@ -60,7 +60,7 @@ parking_lot = "0.12"
 proc-macro2 = "1.0"
 quote = "1.0"
 rand = "0.8"
-reqwest = { version = "0.11", default-features = false }
+reqwest = { version = "0.12", default-features = false }
 ringbuffer = "0.15"
 schnellru = { version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }

--- a/ic-crypto-getrandom-for-wasm/Cargo.toml
+++ b/ic-crypto-getrandom-for-wasm/Cargo.toml
@@ -4,7 +4,11 @@ version.workspace = true
 edition.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
+candid = { workspace = true }
 getrandom = { version = "0.2", features = ["custom"] }
+ic-cdk = { workspace = true }
+ic-cdk-timers = { workspace = true }
+rand = { workspace = true, features = ["getrandom"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 getrandom = { version = "0.2" }

--- a/ic-crypto-getrandom-for-wasm/Cargo.toml
+++ b/ic-crypto-getrandom-for-wasm/Cargo.toml
@@ -4,12 +4,8 @@ version.workspace = true
 edition.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-candid = { workspace = true }
 getrandom = { version = "0.2", features = ["custom"] }
-ic-cdk = { workspace = true }
-ic-cdk-timers = { workspace = true }
 rand = { workspace = true, features = ["getrandom"] }
-rand_chacha = "0.3"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 getrandom = { version = "0.2" }

--- a/ic-crypto-getrandom-for-wasm/Cargo.toml
+++ b/ic-crypto-getrandom-for-wasm/Cargo.toml
@@ -9,6 +9,7 @@ getrandom = { version = "0.2", features = ["custom"] }
 ic-cdk = { workspace = true }
 ic-cdk-timers = { workspace = true }
 rand = { workspace = true, features = ["getrandom"] }
+rand_chacha = "0.3"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 getrandom = { version = "0.2" }

--- a/ic-crypto-getrandom-for-wasm/Cargo.toml
+++ b/ic-crypto-getrandom-for-wasm/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2", features = ["custom"] }
-rand = { workspace = true, features = ["getrandom"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 getrandom = { version = "0.2" }

--- a/ic-crypto-getrandom-for-wasm/src/lib.rs
+++ b/ic-crypto-getrandom-for-wasm/src/lib.rs
@@ -25,14 +25,14 @@
     target_vendor = "unknown",
     target_os = "unknown"
 ))]
-getrandom::register_custom_getrandom!(custom_getrandom_impl::custom_rand);
+pub use custom_getrandom_impl::register_custom_getrandom;
 
 #[cfg(all(
     target_family = "wasm",
     target_vendor = "unknown",
     target_os = "unknown"
 ))]
-pub mod custom_getrandom_impl {
+mod custom_getrandom_impl {
     use std::cell::RefCell;
     use std::time::Duration;
 
@@ -44,10 +44,14 @@ pub mod custom_getrandom_impl {
         static RNG: RefCell<Option<StdRng>> = const { RefCell::new(None) };
     }
 
-    pub fn custom_rand(buf: &mut [u8]) -> Result<(), getrandom::Error> {
+    pub fn register_custom_getrandom() {
         ic_cdk_timers::set_timer(Duration::from_secs(0), || {
             ic_cdk::spawn(generate_randomness())
         });
+        getrandom::register_custom_getrandom!(custom_rand);
+    }
+
+    fn custom_rand(buf: &mut [u8]) -> Result<(), getrandom::Error> {
         RNG.with(|rng| rng.borrow_mut().as_mut().unwrap().fill_bytes(buf));
         Ok(())
     }

--- a/ic-crypto-getrandom-for-wasm/src/lib.rs
+++ b/ic-crypto-getrandom-for-wasm/src/lib.rs
@@ -19,6 +19,17 @@
 //! See the [getrandom
 //! documentation](https://docs.rs/getrandom/latest/getrandom/macro.register_custom_getrandom.html)
 //! for more details on custom implementations.
+//!
+//! To register this custom implementation, call the function inside of your canister's `init` method
+//! or wherever canister initialization happens, with conditional compilation, like this:
+//!
+//! ```ignore
+//! #[init]
+//! pub fn init(&mut self) {
+//!    #[cfg(target_family = "wasm")]
+//!    ic_crypto_getrandom_for_wasm::register_custom_getrandom();
+//! }
+//! ```
 
 #[cfg(all(
     target_family = "wasm",


### PR DESCRIPTION
# Motivation

The `ic-crypto-getrandom-for-wasm` package, which is a workaround for the `getrandom` dependency issues in WASM environments, doesn't work in all cases. Sometimes, just including the package in `Cargo.toml` isn't enough.

This PR provides a fix that changes how this package is consumed...
To register this new custom implementation, call the function inside of your canister's `init` method or wherever canister initialization happens, with conditional compilation, like this:

```rust
#[init]
pub fn init(&mut self) {
    #[cfg(target_family = "wasm")]
    ic_crypto_getrandom_for_wasm::register_custom_getrandom();
}
```

# Changes

- [x] Refactored implementation and export of `ic-crypto-getrandom-for-wasm::register_custom_getrandom` function.
- [x] Updated crate-level doc to reflect usage example.

# Closes

- [x] Ticket: https://infinityswap.atlassian.net/browse/EPROD-828

# NOTE

- [ ] This implementation has only been tested against a couple of canisters locally. Thorough testing against other canisters is highly recommended.