### PR TITLE
Add timeout retry policy to the scheduler

### DIFF
--- a/ic-task-scheduler/src/retry.rs
+++ b/ic-task-scheduler/src/retry.rs
@@ -2,6 +2,7 @@ use core::fmt::Debug;
 
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
+use ic_kit::ic;
 
 /// Defines the strategy to apply in case of a failure.
 /// This is applied, for example, when a task execution fails
@@ -39,6 +40,10 @@ pub enum RetryPolicy {
     MaxRetries { retries: u32 },
     /// The operation will be retried an infinite number of times.
     Infinite,
+    /// The operation will be retried until the current timestamp surpasses the `timeout_ts`.
+    ///
+    /// Timestamp is defined as an IC timestamp, e.g. number of nanoseconds since Unix epoch in `u64`.
+    Timeout { timeout_ts: u64 },
 }
 
 impl RetryPolicy {
@@ -50,6 +55,7 @@ impl RetryPolicy {
                 RetryPolicy::None => false,
                 RetryPolicy::Infinite => true,
                 RetryPolicy::MaxRetries { retries: attempts } => *attempts >= failed_attempts,
+                RetryPolicy::Timeout { timeout_ts } => ic::time() <= *timeout_ts,
             }
         }
     }
@@ -107,7 +113,7 @@ impl BackoffPolicy {
 
 #[cfg(test)]
 pub mod test {
-
+    use ic_kit::{Context, MockContext};
     use super::*;
 
     #[test]
@@ -351,5 +357,13 @@ pub mod test {
         assert!(RetryPolicy::Infinite.should_retry(1));
         assert!(RetryPolicy::Infinite.should_retry(u32::MAX));
         assert!(RetryPolicy::Infinite.should_retry(u32::MAX - 1));
+
+        let ctx = MockContext::new().inject();
+        assert!(RetryPolicy::Timeout { timeout_ts: 0 }.should_retry(0));
+        assert!(!RetryPolicy::Timeout { timeout_ts: 0 }.should_retry(1));
+        assert!(!RetryPolicy::Timeout { timeout_ts: ctx.time() - 1 }.should_retry(1));
+        assert!(RetryPolicy::Timeout { timeout_ts: ctx.time() }.should_retry(1));
+        assert!(RetryPolicy::Timeout { timeout_ts: ctx.time() + 1 }.should_retry(1));
+        assert!(RetryPolicy::Timeout { timeout_ts: u64::MAX }.should_retry(1));
     }
 }

--- a/ic-task-scheduler/src/retry.rs
+++ b/ic-task-scheduler/src/retry.rs
@@ -1,8 +1,8 @@
 use core::fmt::Debug;
 
 use candid::CandidType;
-use serde::{Deserialize, Serialize};
 use ic_kit::ic;
+use serde::{Deserialize, Serialize};
 
 /// Defines the strategy to apply in case of a failure.
 /// This is applied, for example, when a task execution fails
@@ -114,6 +114,7 @@ impl BackoffPolicy {
 #[cfg(test)]
 pub mod test {
     use ic_kit::{Context, MockContext};
+
     use super::*;
 
     #[test]
@@ -361,9 +362,21 @@ pub mod test {
         let ctx = MockContext::new().inject();
         assert!(RetryPolicy::Timeout { timeout_ts: 0 }.should_retry(0));
         assert!(!RetryPolicy::Timeout { timeout_ts: 0 }.should_retry(1));
-        assert!(!RetryPolicy::Timeout { timeout_ts: ctx.time() - 1 }.should_retry(1));
-        assert!(RetryPolicy::Timeout { timeout_ts: ctx.time() }.should_retry(1));
-        assert!(RetryPolicy::Timeout { timeout_ts: ctx.time() + 1 }.should_retry(1));
-        assert!(RetryPolicy::Timeout { timeout_ts: u64::MAX }.should_retry(1));
+        assert!(!RetryPolicy::Timeout {
+            timeout_ts: ctx.time() - 1
+        }
+        .should_retry(1));
+        assert!(RetryPolicy::Timeout {
+            timeout_ts: ctx.time()
+        }
+        .should_retry(1));
+        assert!(RetryPolicy::Timeout {
+            timeout_ts: ctx.time() + 1
+        }
+        .should_retry(1));
+        assert!(RetryPolicy::Timeout {
+            timeout_ts: u64::MAX
+        }
+        .should_retry(1));
     }
 }


### PR DESCRIPTION
In some cases we want to retry the operation with some interval until some fixed moment in the future. For example, we want to wait for a transaction in BTC network to be taken from the mempool and mined into a block, and we want to wait for a set time (most mempools will drop transaction from the mempool in 24 or 72 hours).