### PR TITLE
Add unrecoverable scheduler error

### DIFF
--- a/ic-task-scheduler/src/error.rs
+++ b/ic-task-scheduler/src/error.rs
@@ -4,8 +4,19 @@ use thiserror::Error;
 
 #[derive(CandidType, Debug, Error, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub enum SchedulerError {
+    /// Recoverable error during a scheduler task execution.
+    ///
+    /// If task execution returns this type of error, the task will be retried according to the
+    /// retry policy set for this task.
     #[error("TaskExecutionFailed: {0}")]
     TaskExecutionFailed(String),
+
+    /// Error during task execution that is unlikely to be fixed by retrying the task.
+    ///
+    /// If a task returns this type of error, the task will not be rescheduled according to the
+    /// retry policy and will be considered failed right away.
+    #[error("Unrecoverable task error: {0}")]
+    Unrecoverable(String),
 }
 
 /// Result type for the scheduler


### PR DESCRIPTION
Currently there are two ways for a scheduler task to fail:
1. Return a `SchedulerError::TaskExecutionFailed` error to make the schduler retry the task execution according to the retry policy. When the maxim retries number is achieved, the task is marked as failed.
2. Panic inside the task to revert any state changes and make the scheduler kill the task by timeout.

In some cases we need the task to fail without retries, but to preserve the state update by the task. For example, if the input data given to the task is incorrect, we want to set operation state as failed and complete, as this operation cannot be retried in the future with the same input data, and we don't want to retry the operation according to the retry policy.

For such cases, I add an `Unrecoverable` error type for the scheduler. When such an error is returned by the task, the scheduler will mark the task as failed right away, but will preserve the state changes done by the task execution.