### PR TITLE
Add common logger canister trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ async-recursion = "1.0.2"
 async-trait = "0.1"
 auto_ops = "0.3"
 bincode = "1.3"
+cfg-if = "1.0"
 criterion = "0.5.1"
 crypto-bigint = { version = "0.5", features = ["serde"] }
 dirs = "5.0"

--- a/ic-log/Cargo.toml
+++ b/ic-log/Cargo.toml
@@ -30,6 +30,7 @@ export-api = []
 [[example]]
 name = "log_canister"
 path = "examples/log_canister.rs"
+required-features = ["canister"]
 
 [[test]]
 name = "in_memory_logger"

--- a/ic-log/Cargo.toml
+++ b/ic-log/Cargo.toml
@@ -9,8 +9,12 @@ edition.workspace = true
 anyhow = { workspace = true }
 arc-swap = { workspace = true }
 candid = { workspace = true }
+cfg-if = { workspace = true, optional = true }
 env_filter = { workspace = true }
 humantime = { workspace = true }
+ic-canister = { path = "../ic-canister/ic-canister", optional = true }
+ic-stable-structures = { path = "../ic-stable-structures", optional = true }
+ic-storage = { path = "../ic-storage", optional = true }
 ic-exports = { path = "../ic-exports" }
 log = { workspace = true }
 ringbuffer = { workspace = true }
@@ -20,8 +24,13 @@ serde = { workspace = true }
 ic-canister = { path = "../ic-canister/ic-canister" }
 
 [features]
+canister = ["export-api", "ic-canister", "ic-storage", "ic-stable-structures", "cfg-if"]
 export-api = []
 
 [[example]]
 name = "log_canister"
 path = "examples/log_canister.rs"
+
+[[test]]
+name = "in_memory_logger"
+required-features = ["canister"]

--- a/ic-log/examples/log_canister.rs
+++ b/ic-log/examples/log_canister.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use candid::Principal;
 use ic_canister::{generate_idl, init, Canister, Idl, PreUpdate};
-use ic_exports::ic_cdk::inspect_message;
+use ic_exports::ic_cdk;
 use ic_exports::ic_kit::ic;
 use ic_log::canister::inspect::logger_canister_inspect;
 use ic_log::canister::{LogCanister, LogState};
@@ -25,7 +25,7 @@ impl LogCanister for LoggerCanister {
     }
 }
 
-#[inspect_message]
+#[ic_cdk::inspect_message]
 fn inspect() {
     logger_canister_inspect()
 }

--- a/ic-log/examples/log_canister.rs
+++ b/ic-log/examples/log_canister.rs
@@ -5,9 +5,9 @@ use std::rc::Rc;
 use candid::Principal;
 use ic_canister::{generate_idl, init, query, update, Canister, Idl, PreUpdate};
 use ic_exports::ic_kit::ic;
-use ic_log::did::{LogSettings, LoggerPermission};
+use ic_log::did::LoggerPermission;
 use ic_log::writer::Logs;
-use ic_log::{init_log, LoggerConfig};
+use ic_log::{init_log, LogSettings, LoggerConfig};
 use log::{debug, error, info};
 
 #[derive(Canister)]
@@ -23,6 +23,7 @@ impl LogCanister {
     pub fn init(&self) {
         let settings = LogSettings {
             in_memory_records: 128,
+            max_record_length: 1024,
             log_filter: "info".to_string(),
             enable_console: true,
             acl: [

--- a/ic-log/examples/log_canister.rs
+++ b/ic-log/examples/log_canister.rs
@@ -4,8 +4,10 @@ use std::rc::Rc;
 
 use candid::Principal;
 use ic_canister::{generate_idl, init, query, update, Canister, Idl, PreUpdate};
+use ic_exports::ic_kit::ic;
+use ic_log::did::{LogSettings, LoggerPermission};
 use ic_log::writer::Logs;
-use ic_log::{init_log, LogSettings, LoggerConfig};
+use ic_log::{init_log, LoggerConfig};
 use log::{debug, error, info};
 
 #[derive(Canister)]
@@ -20,9 +22,14 @@ impl LogCanister {
     #[init]
     pub fn init(&self) {
         let settings = LogSettings {
-            in_memory_records: Some(128),
-            log_filter: Some("info".to_string()),
+            in_memory_records: 128,
+            log_filter: "info".to_string(),
             enable_console: true,
+            acl: [
+                (ic::caller(), LoggerPermission::Read),
+                (ic::caller(), LoggerPermission::Configure),
+            ]
+            .into(),
         };
         match init_log(&settings) {
             Ok(logger_config) => LoggerConfigService::default().init(logger_config),

--- a/ic-log/examples/log_canister.rs
+++ b/ic-log/examples/log_canister.rs
@@ -1,108 +1,61 @@
 use std::cell::RefCell;
-use std::marker::PhantomData;
 use std::rc::Rc;
 
 use candid::Principal;
-use ic_canister::{generate_idl, init, query, update, Canister, Idl, PreUpdate};
+use ic_canister::{generate_idl, init, Canister, Idl, PreUpdate};
+use ic_exports::ic_cdk::inspect_message;
 use ic_exports::ic_kit::ic;
-use ic_log::did::LoggerPermission;
-use ic_log::writer::Logs;
-use ic_log::{init_log, LogSettings, LoggerConfig};
-use log::{debug, error, info};
+use ic_log::canister::inspect::logger_canister_inspect;
+use ic_log::canister::{LogCanister, LogState};
+use ic_log::did::LogCanisterSettings;
+use ic_stable_structures::MemoryId;
+use ic_storage::IcStorage;
 
 #[derive(Canister)]
-pub struct LogCanister {
+pub struct LoggerCanister {
     #[id]
     id: Principal,
 }
 
-impl PreUpdate for LogCanister {}
+impl PreUpdate for LoggerCanister {}
 
-impl LogCanister {
+impl LogCanister for LoggerCanister {
+    fn log_state(&self) -> Rc<RefCell<LogState>> {
+        LogState::get()
+    }
+}
+
+#[inspect_message]
+fn inspect() {
+    logger_canister_inspect()
+}
+
+impl LoggerCanister {
     #[init]
     pub fn init(&self) {
-        let settings = LogSettings {
-            in_memory_records: 128,
-            max_record_length: 1024,
-            log_filter: "info".to_string(),
-            enable_console: true,
-            acl: [
-                (ic::caller(), LoggerPermission::Read),
-                (ic::caller(), LoggerPermission::Configure),
-            ]
-            .into(),
+        let settings = LogCanisterSettings {
+            log_filter: Some("trace".into()),
+            in_memory_records: Some(128),
+            ..Default::default()
         };
-        match init_log(&settings) {
-            Ok(logger_config) => LoggerConfigService::default().init(logger_config),
-            Err(err) => {
-                ic_exports::ic_cdk::println!("error configuring the logger. Err: {:?}", err)
-            }
-        }
-        info!("LogCanister initialized");
+
+        self.log_state()
+            .borrow_mut()
+            .init(ic::caller(), MemoryId::new(1), settings)
+            .expect("error configuring the logger");
     }
 
-    #[query]
-    pub fn get_log_records(&self, count: usize) -> Logs {
-        debug!("collecting {count} log records");
-        ic_log::take_memory_records(count, 0)
-    }
-
-    #[update]
-    pub async fn log_info(&self, text: String) {
-        info!("{text}");
-    }
-
-    #[update]
-    pub async fn log_debug(&self, text: String) {
-        debug!("{text}");
-    }
-
-    #[update]
-    pub async fn log_error(&self, text: String) {
-        error!("{text}");
-    }
-
-    #[update]
-    pub async fn set_logger_filter(&self, filter: String) {
-        LoggerConfigService::default().set_logger_filter(&filter);
-        debug!("log filter set to {filter}");
-    }
-
-    pub fn idl() -> Idl {
+    pub fn get_idl() -> Idl {
         generate_idl!()
     }
 }
 
-type ForceNotSendAndNotSync = PhantomData<Rc<()>>;
-
-thread_local! {
-    static LOGGER_CONFIG: RefCell<Option<LoggerConfig>> = const { RefCell::new(None) };
-}
-
-#[derive(Debug, Default)]
-/// Handles the runtime logger configuration
-pub struct LoggerConfigService(ForceNotSendAndNotSync);
-
-impl LoggerConfigService {
-    /// Sets a new LoggerConfig
-    pub fn init(&self, logger_config: LoggerConfig) {
-        LOGGER_CONFIG.with(|config| config.borrow_mut().replace(logger_config));
-    }
-
-    /// Changes the logger filter at runtime
-    pub fn set_logger_filter(&self, filter: &str) {
-        LOGGER_CONFIG.with(|config| match *config.borrow_mut() {
-            Some(ref logger_config) => {
-                logger_config.update_filters(filter);
-            }
-            None => panic!("LoggerConfig not initialized"),
-        });
-    }
-}
-
 fn main() {
-    let canister_e_idl = LogCanister::idl();
-    let idl = candid::pretty::candid::compile(&canister_e_idl.env.env, &Some(canister_e_idl.actor));
+    let canister_idl = LoggerCanister::get_idl();
+    let mut idl = <LoggerCanister as LogCanister>::get_idl();
+    idl.merge(&canister_idl);
+
+    let idl = candid::pretty::candid::compile(&idl.env.env, &Some(idl.actor));
 
     println!("{}", idl);
 }

--- a/ic-log/src/canister.rs
+++ b/ic-log/src/canister.rs
@@ -11,6 +11,7 @@ pub use crate::canister::state::LogState;
 use crate::did::{LogCanisterError, LogCanisterSettings, LoggerPermission, Pagination};
 use crate::writer::Logs;
 
+pub mod inspect;
 mod state;
 
 pub trait LogCanister: Canister + PreUpdate {

--- a/ic-log/src/canister.rs
+++ b/ic-log/src/canister.rs
@@ -14,25 +14,88 @@ use crate::writer::Logs;
 pub mod inspect;
 mod state;
 
+/// Canister trait that provides common method for configuring and using canister logger.
+///
+/// Check out the `log_canister` example in the `examples` directory for a guide on how to add these
+/// methods to you canister. In short, to use this implementation of the logger, you need to:
+///
+/// * implement `LogCanister` trait for your type
+/// * call [`LogState::init`] method from the `#[init]` method of your canister.
+/// * call [`inspect::logger_canister_inspect`] function from the `#[inspect_message]` method of
+///   your canister.
+///
+/// # Permissions
+///
+/// Most operations in the `LogCanister` require the caller to have [`LoggerPermission`]s assigned
+/// to them.
+///
+/// * `Read` permission allows a principal to get the logs with `ic_logs` method.
+/// * `Configure` permission allows changing the logger configuration and manager logger permissions.
+///   If a principal has `Configure` permission, `Read` permission is also assumed for that
+///   principal.
+///
+/// # Configuration and ways to get logs
+///
+/// There are two ways to get the logs from the logger canister:
+///
+/// 1. Using IC management canister `get_canister_logs` method. To make the canister write logs
+///    with the IC API, [`LogCanisterSettings::enable_console`] must be set to `true` (it
+///    is enabled by default, so if `None` is given at the canister initialization, it will also
+///    be considered as `true`). The logs written by this method are not affected by other
+///    settings, such as number of in-memory logs and max log entry length (but they do apply the
+///    logging filter). Also, they use native IC approach for checking permissions to get the logs
+///    (it can be configured to allow access to the logs only to the canister controllers or to
+///    anyone using the canister settings). This method can be used to get logs from trapped
+///    operations.
+///
+/// 2. Using canister `ic_logs` method. Logs returned by this method are stored in the canister
+///    memory. To limit the size of the memory that can be dedicated to the logs, configure
+///    max number of entries to store and max size of a single entry. This method cannot store
+///    logs from operations that trapped, and the logs storage is reset when the canister is
+///    upgraded.
 pub trait LogCanister: Canister + PreUpdate {
+    /// State of the logger. Usually the implementation of this method would look like:
+    ///
+    /// ```ignore
+    /// use ic_storage::IcStorage;
+    /// fn log_state(&self) -> Rc<RefCell<LogState>> {
+    ///     LogState::get()
+    /// }
+    /// ```
     #[state_getter]
     fn log_state(&self) -> Rc<RefCell<LogState>>;
 
-    /// Gets the logs
-    /// - `count` is the number of logs to return
+    /// Returns canister logs.
+    ///
+    /// To use this method the caller must have [`LoggerPermission::Read`] permission.
+    ///
+    /// `pagination.offset` value specifies an absolute identifier of the first log entry to be
+    /// returned. If the given offset is larger than the max id of the logs in the canister,
+    /// an empty response will be returned.
+    ///
+    /// To get the maximum identifier of the logs currently stored in the canister, this method
+    /// can be used with `pagination.count == 0`.
+    ///
+    /// # Traps
+    ///
+    /// Traps if the caller does not have [`LoggerPermission::Read`] permission.
     #[query(trait = true)]
-    fn ic_logs(&self, page: Pagination) -> Logs {
+    fn ic_logs(&self, pagination: Pagination) -> Logs {
         self.log_state()
             .borrow()
-            .get_logs(ic::caller(), page)
+            .get_logs(ic::caller(), pagination)
             .expect("Failed to get logs.")
     }
 
-    /// Updates the runtime configuration of the logger with a new filter in the same form as the `RUST_LOG`
-    /// environment variable.
-    /// Example of valid filters:
-    /// - info
-    /// - debug,crate1::mod1=error,crate1::mod2,crate2=debug
+    /// Sets the logger filter string.
+    ///
+    /// To call this method, the caller must have [`LoggerPermission::Configure`] permission.
+    ///
+    /// To turn off logging for the canister, use `filter == "off"`.
+    ///
+    /// # Traps
+    ///
+    /// Traps if the caller doesn't have [`LoggerPermission::Configure`] permission.
     #[update(trait = true)]
     fn set_logger_filter(&mut self, filter: String) -> Result<(), LogCanisterError> {
         self.log_state()
@@ -40,6 +103,13 @@ pub trait LogCanister: Canister + PreUpdate {
             .set_logger_filter(ic::caller(), filter)
     }
 
+    /// Updates the maximum number of log entries stored in the canister memory.
+    ///
+    /// To call this method, the caller must have [`LoggerPermission::Configure`] permission.
+    ///
+    /// # Traps
+    ///
+    /// Traps if the caller doesn't have [`LoggerPermission::Configure`] permission.
     #[update(trait = true)]
     fn set_logger_in_memory_records(
         &mut self,
@@ -50,11 +120,19 @@ pub trait LogCanister: Canister + PreUpdate {
             .set_in_memory_records(ic::caller(), max_log_count)
     }
 
+    /// Returns the current logger settings.
     #[query(trait = true)]
     fn get_logger_settings(&self) -> LogCanisterSettings {
         self.log_state().borrow().get_settings().clone().into()
     }
 
+    /// Add the given `permission` to the `to` principal.
+    ///
+    /// To call this method, the caller must have [`LoggerPermission::Configure`] permission.
+    ///
+    /// # Traps
+    ///
+    /// Traps if the caller doesn't have [`LoggerPermission::Configure`] permission.
     #[update(trait = true)]
     fn add_logger_permission(&mut self, to: Principal, permission: LoggerPermission) {
         self.log_state()
@@ -63,6 +141,13 @@ pub trait LogCanister: Canister + PreUpdate {
             .expect("Failed to add logger permission");
     }
 
+    /// Remove the given `permission` from the `from` principal.
+    ///
+    /// To call this method, the caller must have [`LoggerPermission::Configure`] permission.
+    ///
+    /// # Traps
+    ///
+    /// Traps if the caller doesn't have [`LoggerPermission::Configure`] permission.
     #[update(trait = true)]
     fn remove_logger_permission(&mut self, from: Principal, permission: LoggerPermission) {
         self.log_state()
@@ -71,6 +156,7 @@ pub trait LogCanister: Canister + PreUpdate {
             .expect("Failed to remove logger permission");
     }
 
+    /// Return idl of the logger canister.
     fn get_idl() -> Idl {
         generate_idl!()
     }

--- a/ic-log/src/canister.rs
+++ b/ic-log/src/canister.rs
@@ -1,0 +1,101 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use candid::Principal;
+use ic_canister::{
+    generate_exports, generate_idl, query, state_getter, update, Canister, Idl, PreUpdate,
+};
+use ic_exports::ic_kit::ic;
+
+pub use crate::canister::state::LogState;
+use crate::did::{LogCanisterError, LogSettings, LoggerPermission, Pagination};
+use crate::writer::Logs;
+
+mod state;
+
+pub trait LogCanister: Canister + PreUpdate {
+    #[state_getter]
+    fn log_state(&self) -> Rc<RefCell<LogState>>;
+
+    /// Gets the logs
+    /// - `count` is the number of logs to return
+    #[query(trait = true)]
+    fn ic_logs(&self, page: Pagination) -> Logs {
+        self.log_state()
+            .borrow()
+            .get_logs(ic::caller(), page)
+            .expect("Failed to get logs.")
+    }
+
+    /// Updates the runtime configuration of the logger with a new filter in the same form as the `RUST_LOG`
+    /// environment variable.
+    /// Example of valid filters:
+    /// - info
+    /// - debug,crate1::mod1=error,crate1::mod2,crate2=debug
+    #[update(trait = true)]
+    fn set_logger_filter(&mut self, filter: String) -> Result<(), LogCanisterError> {
+        self.log_state()
+            .borrow_mut()
+            .set_logger_filter(ic::caller(), filter)
+    }
+
+    #[query(trait = true)]
+    fn get_logger_settings(&self) -> LogSettings {
+        self.log_state().borrow().get_settings().clone()
+    }
+
+    #[update(trait = true)]
+    fn add_logger_permission(&mut self, to: Principal, permission: LoggerPermission) {
+        self.log_state()
+            .borrow_mut()
+            .add_permission(ic::caller(), to, permission)
+            .expect("Failed to add logger permission");
+    }
+
+    #[update(trait = true)]
+    fn remove_logger_permission(&mut self, from: Principal, permission: LoggerPermission) {
+        self.log_state()
+            .borrow_mut()
+            .remove_permission(ic::caller(), from, permission)
+            .expect("Failed to remove logger permission");
+    }
+
+    fn get_idl() -> Idl {
+        generate_idl!()
+    }
+}
+
+generate_exports!(LogCanister);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct LogTestImpl {}
+    impl Canister for LogTestImpl {
+        fn init_instance() -> Self {
+            todo!()
+        }
+
+        fn from_principal(_principal: Principal) -> Self {
+            todo!()
+        }
+
+        fn principal(&self) -> Principal {
+            todo!()
+        }
+    }
+
+    impl PreUpdate for LogTestImpl {}
+    impl LogCanister for LogTestImpl {
+        fn log_state(&self) -> Rc<RefCell<LogState>> {
+            todo!()
+        }
+    }
+
+    #[test]
+    fn generates_idl() {
+        let idl = LogTestImpl::get_idl();
+        assert!(!format!("{idl}").is_empty())
+    }
+}

--- a/ic-log/src/canister.rs
+++ b/ic-log/src/canister.rs
@@ -8,7 +8,7 @@ use ic_canister::{
 use ic_exports::ic_kit::ic;
 
 pub use crate::canister::state::LogState;
-use crate::did::{LogCanisterError, LogSettings, LoggerPermission, Pagination};
+use crate::did::{LogCanisterError, LogCanisterSettings, LoggerPermission, Pagination};
 use crate::writer::Logs;
 
 mod state;
@@ -39,9 +39,19 @@ pub trait LogCanister: Canister + PreUpdate {
             .set_logger_filter(ic::caller(), filter)
     }
 
+    #[update(trait = true)]
+    fn set_logger_in_memory_records(
+        &mut self,
+        max_log_count: usize,
+    ) -> Result<(), LogCanisterError> {
+        self.log_state()
+            .borrow_mut()
+            .set_in_memory_records(ic::caller(), max_log_count)
+    }
+
     #[query(trait = true)]
-    fn get_logger_settings(&self) -> LogSettings {
-        self.log_state().borrow().get_settings().clone()
+    fn get_logger_settings(&self) -> LogCanisterSettings {
+        self.log_state().borrow().get_settings().clone().into()
     }
 
     #[update(trait = true)]

--- a/ic-log/src/canister/inspect.rs
+++ b/ic-log/src/canister/inspect.rs
@@ -5,19 +5,25 @@ use ic_storage::IcStorage;
 use crate::canister::LogState;
 use crate::did::LoggerPermission;
 
+/// Implementation of canister inspect logic for logger canister. Call this method from the
+/// `#[inspect_message]` function of your canister.
+///
+/// # Traps
+///
+/// Traps with a corresponding method if logger permission check is not passed.
 pub fn logger_canister_inspect() {
     let method = api::call::method_name();
-    let state = LogState::get().borrow();
+    let state = LogState::get();
+    let state = state.borrow();
     let caller = ic::caller();
 
     match method.as_str() {
-        "ic_logs" => state.check_permissions(caller, LoggerPermission::Read),
+        "ic_logs" => state.check_permission(caller, LoggerPermission::Read),
         "set_logger_filter"
         | "set_logger_in_memory_records"
         | "add_logger_permission"
-        | "remove_logger_permission" => {
-            state.check_permissions(caller, LoggerPermission::Configure)
-        }
-        _ => {}
+        | "remove_logger_permission" => state.check_permission(caller, LoggerPermission::Configure),
+        _ => Ok(()),
     }
+    .expect("inspect check failed");
 }

--- a/ic-log/src/canister/inspect.rs
+++ b/ic-log/src/canister/inspect.rs
@@ -1,0 +1,23 @@
+use ic_exports::ic_cdk::api;
+use ic_exports::ic_kit::ic;
+use ic_storage::IcStorage;
+
+use crate::canister::LogState;
+use crate::did::LoggerPermission;
+
+pub fn logger_canister_inspect() {
+    let method = api::call::method_name();
+    let state = LogState::get().borrow();
+    let caller = ic::caller();
+
+    match method.as_str() {
+        "ic_logs" => state.check_permissions(caller, LoggerPermission::Read),
+        "set_logger_filter"
+        | "set_logger_in_memory_records"
+        | "add_logger_permission"
+        | "remove_logger_permission" => {
+            state.check_permissions(caller, LoggerPermission::Configure)
+        }
+        _ => {}
+    }
+}

--- a/ic-log/src/canister/state.rs
+++ b/ic-log/src/canister/state.rs
@@ -206,7 +206,7 @@ impl LogState {
         Ok(())
     }
 
-    fn check_permission(
+    pub(crate) fn check_permission(
         &self,
         caller: Principal,
         logger_permission: LoggerPermission,

--- a/ic-log/src/canister/state.rs
+++ b/ic-log/src/canister/state.rs
@@ -105,7 +105,7 @@ impl LogState {
     ) -> Result<(), LogCanisterError> {
         self.check_permission(caller, LoggerPermission::Configure)?;
 
-        self.settings.log_filter = filter_value.clone();
+        self.settings.log_filter.clone_from(&filter_value);
         LOGGER_CONFIG.with(|config| {
             if let Some(config) = &mut *config.borrow_mut() {
                 config.update_filters(&filter_value);

--- a/ic-log/src/canister/state.rs
+++ b/ic-log/src/canister/state.rs
@@ -1,0 +1,581 @@
+use std::borrow::Cow;
+use std::cell::RefCell;
+
+use candid::{Decode, Encode, Principal};
+use ic_stable_structures::stable_structures::DefaultMemoryImpl;
+use ic_stable_structures::{Bound, CellStructure, IcMemoryManager, MemoryId, StableCell, Storable};
+use ic_storage::IcStorage;
+
+use crate::did::{LogCanisterError, LogSettings, LoggerAcl, LoggerPermission, Pagination};
+use crate::writer::Logs;
+use crate::{take_memory_records, LoggerConfig};
+
+thread_local! {
+    static MEMORY_MANAGER: IcMemoryManager<DefaultMemoryImpl> = IcMemoryManager::init(DefaultMemoryImpl::default());
+    static LOGGER_CONFIG: RefCell<Option<LoggerConfig>> = const { RefCell::new(None) };
+}
+
+#[derive(Debug, Clone, IcStorage)]
+pub struct LogState {
+    settings: LogSettings,
+    memory_id: MemoryId,
+}
+
+impl Default for LogState {
+    fn default() -> Self {
+        Self {
+            settings: LogSettings::default(),
+            memory_id: Self::INVALID_MEMORY_ID,
+        }
+    }
+}
+
+impl LogState {
+    const INVALID_MEMORY_ID: MemoryId = MemoryId::new(254);
+
+    pub fn new(memory_id: MemoryId, acl: LoggerAcl) -> Self {
+        let mut this = Self::default();
+        this.memory_id = memory_id;
+        this.settings.acl = acl;
+
+        this
+    }
+
+    pub fn init(
+        &mut self,
+        memory_id: MemoryId,
+        log_settings: LogSettings,
+    ) -> Result<(), LogCanisterError> {
+        if LOGGER_CONFIG.with(|logger_config| logger_config.borrow().is_some()) {
+            return Err(LogCanisterError::AlreadyInitialized);
+        }
+
+        self.settings = log_settings.clone();
+        self.memory_id = memory_id;
+
+        self.store()?;
+
+        Self::init_log(&log_settings)?;
+
+        // Print this out without using log in case the given parameters prevent logs to be printed.
+        #[cfg(target_arch = "wasm32")]
+        ic_exports::ic_kit::ic::print(format!(
+            "Initialized logging with settings: {log_settings:?}"
+        ));
+
+        Ok(())
+    }
+
+    pub fn get_settings(&self) -> &LogSettings {
+        &self.settings
+    }
+
+    pub fn set_logger_filter(
+        &mut self,
+        caller: Principal,
+        filter_value: String,
+    ) -> Result<(), LogCanisterError> {
+        self.check_permission(caller, LoggerPermission::Configure)?;
+
+        self.settings.log_filter = filter_value.clone();
+        LOGGER_CONFIG.with(|config| {
+            if let Some(config) = &mut *config.borrow_mut() {
+                config.update_filters(&filter_value);
+            }
+        });
+
+        self.store().expect("Failed to update logger filter");
+
+        log::info!("Updated log filter to: {filter_value:?}");
+
+        Ok(())
+    }
+    //
+    // pub fn update_in_memory_records(&mut self, count: usize) {
+    //     self.settings.in_memory_records = count;
+    //     todo!();
+    //
+    //     self.store()
+    //         .expect("Failed to update logger in memory records count");
+    // }
+
+    pub fn get_logs(&self, caller: Principal, page: Pagination) -> Result<Logs, LogCanisterError> {
+        self.check_permission(caller, LoggerPermission::Read)?;
+        Ok(take_memory_records(page.count, page.offset))
+    }
+
+    pub fn reload(&mut self, memory_id: MemoryId) -> Result<(), LogCanisterError> {
+        if LOGGER_CONFIG.with(|logger_config| logger_config.borrow().is_some()) {
+            return Err(LogCanisterError::AlreadyInitialized);
+        }
+
+        if memory_id == Self::INVALID_MEMORY_ID {
+            return Err(LogCanisterError::InvalidMemoryId);
+        }
+
+        let settings = MEMORY_MANAGER.with(|mm| {
+            Ok(StableCell::new(
+                mm.get(memory_id),
+                StorableLogSettings(LogSettings::default()),
+            )
+            .map_err(|err| {
+                LogCanisterError::Generic(format!(
+                    "Failed to write log config to the stable storage: {err:?}"
+                ))
+            })?
+            .get()
+            .clone())
+        })?;
+
+        if settings.0 == LogSettings::default() {
+            return Err(LogCanisterError::InvalidMemoryId);
+        }
+
+        self.settings = settings.0;
+        self.memory_id = memory_id;
+
+        Self::init_log(&self.settings)?;
+
+        Ok(())
+    }
+
+    pub fn add_permission(
+        &mut self,
+        caller: Principal,
+        to: Principal,
+        permission: LoggerPermission,
+    ) -> Result<(), LogCanisterError> {
+        self.check_permission(caller, LoggerPermission::Configure)?;
+        self.settings.acl.insert((to, permission));
+        Ok(())
+    }
+
+    pub fn remove_permission(
+        &mut self,
+        caller: Principal,
+        from: Principal,
+        permission: LoggerPermission,
+    ) -> Result<(), LogCanisterError> {
+        self.check_permission(caller, LoggerPermission::Configure)?;
+        self.settings.acl.remove(&(from, permission));
+        Ok(())
+    }
+
+    fn store(&self) -> Result<(), LogCanisterError> {
+        let memory_id = self.memory_id;
+        if memory_id == Self::INVALID_MEMORY_ID {
+            return Err(LogCanisterError::InvalidMemoryId);
+        }
+
+        let log_settings = self.settings.clone();
+        MEMORY_MANAGER
+            .with(|mm| {
+                let mut cell = StableCell::new(
+                    mm.get(memory_id),
+                    StorableLogSettings(LogSettings::default()),
+                )?;
+
+                cell.set(StorableLogSettings(log_settings))
+            })
+            .map_err(|err| {
+                LogCanisterError::Generic(format!(
+                    "Failed to write log config to the stable storage: {err:?}"
+                ))
+            })
+    }
+
+    fn init_log(_log_settings: &LogSettings) -> Result<(), LogCanisterError> {
+        let logger_config = {
+            cfg_if::cfg_if! {
+                if #[cfg(test)] {
+                    let (_, config) = crate::Builder::default().build();
+                    config
+                } else {
+                    crate::init_log(_log_settings).map_err(|_| LogCanisterError::AlreadyInitialized)?
+                }
+            }
+        };
+
+        LOGGER_CONFIG.with(|config| config.borrow_mut().replace(logger_config));
+        Ok(())
+    }
+
+    fn check_permission(
+        &self,
+        caller: Principal,
+        logger_permission: LoggerPermission,
+    ) -> Result<(), LogCanisterError> {
+        let allowed = match logger_permission {
+            LoggerPermission::Read => {
+                self.settings
+                    .acl
+                    .contains(&(caller, LoggerPermission::Read))
+                    || (self
+                        .settings
+                        .acl
+                        .contains(&(caller, LoggerPermission::Configure)))
+            }
+            LoggerPermission::Configure => self
+                .settings
+                .acl
+                .contains(&(caller, LoggerPermission::Configure)),
+        };
+
+        if allowed {
+            Ok(())
+        } else {
+            Err(LogCanisterError::NotAuthorized)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StorableLogSettings(pub LogSettings);
+
+impl Storable for StorableLogSettings {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::from(Encode!(&self.0).unwrap())
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Self(Decode!(&bytes, LogSettings).unwrap())
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn admin() -> Principal {
+        Principal::from_slice(&[1; 20])
+    }
+
+    fn reader() -> Principal {
+        Principal::from_slice(&[2; 20])
+    }
+
+    fn user() -> Principal {
+        Principal::from_slice(&[5; 20])
+    }
+
+    fn test_memory() -> MemoryId {
+        MemoryId::new(2)
+    }
+
+    fn test_settings() -> LogSettings {
+        LogSettings {
+            enable_console: true,
+            in_memory_records: 10,
+            log_filter: "trace".to_string(),
+            acl: [
+                (admin(), LoggerPermission::Configure),
+                (reader(), LoggerPermission::Read),
+            ]
+            .into(),
+        }
+    }
+
+    fn test_state() -> LogState {
+        let mut state = LogState::default();
+        state.init(test_memory(), test_settings()).unwrap();
+        state
+    }
+
+    #[test]
+    fn init_stores_settings() {
+        let mut state = LogState::default();
+        let settings = LogSettings {
+            enable_console: true,
+            in_memory_records: 10,
+            log_filter: "debug".to_string(),
+            acl: [(admin(), LoggerPermission::Configure)].into(),
+        };
+        state.init(MemoryId::new(1), settings.clone()).unwrap();
+
+        assert_eq!(state.get_settings(), &settings);
+    }
+
+    #[test]
+    fn init_configures_logger() {
+        let _ = test_state();
+        LOGGER_CONFIG.with(|config| {
+            assert!(config.borrow().is_some(), "Config is not stored");
+        })
+    }
+
+    #[test]
+    fn init_fails_if_already_initialized() {
+        let mut state = test_state();
+        assert_eq!(
+            state.init(test_memory(), test_settings()),
+            Err(LogCanisterError::AlreadyInitialized)
+        );
+    }
+
+    #[test]
+    fn init_fails_if_default_memory_id() {
+        let mut state = LogState::default();
+        assert_eq!(
+            state.init(LogState::INVALID_MEMORY_ID, LogSettings::default()),
+            Err(LogCanisterError::InvalidMemoryId)
+        );
+    }
+
+    #[test]
+    fn reload_loads_stored_settings() {
+        let mut state = test_state();
+
+        // Simulate canister reload
+        LOGGER_CONFIG.with(|v| *v.borrow_mut() = None);
+        state.settings = LogSettings::default();
+
+        state.reload(test_memory()).unwrap();
+
+        assert_eq!(state.settings, test_settings());
+    }
+
+    #[test]
+    fn reload_configures_logger() {
+        let mut state = test_state();
+
+        // Simulate canister reload
+        LOGGER_CONFIG.with(|v| *v.borrow_mut() = None);
+        state.settings = LogSettings::default();
+
+        state.reload(test_memory()).unwrap();
+
+        assert!(LOGGER_CONFIG.with(|v| v.borrow().is_some()));
+    }
+
+    #[test]
+    fn reload_fails_if_already_initialized() {
+        let mut state = test_state();
+        assert_eq!(
+            state.reload(test_memory()),
+            Err(LogCanisterError::AlreadyInitialized)
+        );
+    }
+
+    #[test]
+    fn reload_fails_if_incorrect_memory_id() {
+        let mut state = test_state();
+
+        // Simulate canister reload
+        LOGGER_CONFIG.with(|v| *v.borrow_mut() = None);
+        state.settings = LogSettings::default();
+
+        assert_eq!(
+            state.reload(MemoryId::new(42)),
+            Err(LogCanisterError::InvalidMemoryId)
+        );
+    }
+
+    #[test]
+    fn add_permission_works() {
+        let mut state = test_state();
+        assert!(state
+            .check_permission(user(), LoggerPermission::Read)
+            .is_err());
+        assert!(state
+            .check_permission(user(), LoggerPermission::Configure)
+            .is_err());
+
+        state
+            .add_permission(admin(), user(), LoggerPermission::Read)
+            .unwrap();
+        assert!(state
+            .check_permission(user(), LoggerPermission::Read)
+            .is_ok());
+        assert!(state
+            .check_permission(user(), LoggerPermission::Configure)
+            .is_err());
+
+        state
+            .add_permission(admin(), user(), LoggerPermission::Configure)
+            .unwrap();
+        assert!(state
+            .check_permission(user(), LoggerPermission::Read)
+            .is_ok());
+        assert!(state
+            .check_permission(user(), LoggerPermission::Configure)
+            .is_ok());
+    }
+
+    #[test]
+    fn add_permission_checks_caller() {
+        let mut state = test_state();
+        assert_eq!(
+            state.add_permission(reader(), user(), LoggerPermission::Configure),
+            Err(LogCanisterError::NotAuthorized)
+        );
+    }
+
+    #[test]
+    fn add_permission_duplicates_is_noop() {
+        let mut state = test_state();
+
+        assert!(state
+            .check_permission(reader(), LoggerPermission::Read)
+            .is_ok());
+        state
+            .add_permission(admin(), reader(), LoggerPermission::Read)
+            .unwrap();
+
+        assert!(state
+            .check_permission(reader(), LoggerPermission::Read)
+            .is_ok());
+        assert!(state
+            .check_permission(reader(), LoggerPermission::Configure)
+            .is_err());
+    }
+
+    #[test]
+    fn add_permission_upgrade_permission_level() {
+        let mut state = test_state();
+
+        assert!(state
+            .check_permission(reader(), LoggerPermission::Read)
+            .is_ok());
+        state
+            .add_permission(admin(), reader(), LoggerPermission::Configure)
+            .unwrap();
+
+        assert!(state
+            .check_permission(reader(), LoggerPermission::Read)
+            .is_ok());
+        assert!(state
+            .check_permission(reader(), LoggerPermission::Configure)
+            .is_ok());
+    }
+
+    #[test]
+    fn add_permission_downgrade_permission_level_is_noop() {
+        let mut state = test_state();
+
+        assert!(state
+            .check_permission(admin(), LoggerPermission::Read)
+            .is_ok());
+        assert!(state
+            .check_permission(admin(), LoggerPermission::Configure)
+            .is_ok());
+
+        state
+            .add_permission(admin(), admin(), LoggerPermission::Read)
+            .unwrap();
+
+        assert!(state
+            .check_permission(admin(), LoggerPermission::Read)
+            .is_ok());
+        assert!(state
+            .check_permission(admin(), LoggerPermission::Configure)
+            .is_ok());
+    }
+
+    #[test]
+    fn configure_permission_grants_read_access() {
+        let mut state = test_state();
+        state
+            .add_permission(admin(), user(), LoggerPermission::Configure)
+            .unwrap();
+        assert!(state
+            .check_permission(user(), LoggerPermission::Configure)
+            .is_ok());
+    }
+
+    #[test]
+    fn remove_permission_works() {
+        let mut state = test_state();
+        assert!(state
+            .check_permission(reader(), LoggerPermission::Read)
+            .is_ok());
+        assert!(state
+            .check_permission(reader(), LoggerPermission::Configure)
+            .is_err());
+
+        state
+            .remove_permission(admin(), reader(), LoggerPermission::Read)
+            .unwrap();
+
+        assert!(state
+            .check_permission(reader(), LoggerPermission::Read)
+            .is_err());
+        assert!(state
+            .check_permission(reader(), LoggerPermission::Configure)
+            .is_err());
+    }
+
+    #[test]
+    fn remove_permission_checks_caller() {
+        let mut state = test_state();
+        assert_eq!(
+            state.remove_permission(reader(), admin(), LoggerPermission::Configure),
+            Err(LogCanisterError::NotAuthorized)
+        );
+    }
+
+    #[test]
+    fn remove_permission_non_existing_is_nop() {
+        let mut state = test_state();
+        state
+            .remove_permission(admin(), user(), LoggerPermission::Read)
+            .unwrap();
+        assert!(state
+            .check_permission(user(), LoggerPermission::Read)
+            .is_err());
+    }
+
+    #[test]
+    fn update_logger_filter_checks_caller() {
+        let mut state = test_state();
+        assert_eq!(
+            state.set_logger_filter(user(), "trace".into()),
+            Err(LogCanisterError::NotAuthorized)
+        );
+    }
+
+    #[test]
+    fn update_logger_filter_updates_stored_settings() {
+        let mut state = test_state();
+        let new_filter = "trace".to_string();
+        state
+            .set_logger_filter(admin(), new_filter.clone())
+            .unwrap();
+        assert_eq!(state.get_settings().log_filter, new_filter);
+    }
+
+    #[test]
+    fn get_logs_checks_permissions() {
+        let state = test_state();
+        let _ = state
+            .get_logs(
+                admin(),
+                Pagination {
+                    offset: 0,
+                    count: 10,
+                },
+            )
+            .unwrap();
+        let _ = state
+            .get_logs(
+                reader(),
+                Pagination {
+                    offset: 0,
+                    count: 10,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(
+            state.get_logs(
+                user(),
+                Pagination {
+                    offset: 0,
+                    count: 10
+                }
+            ),
+            Err(LogCanisterError::NotAuthorized)
+        );
+    }
+}

--- a/ic-log/src/did.rs
+++ b/ic-log/src/did.rs
@@ -16,6 +16,7 @@ pub enum LogCanisterError {
     NotAuthorized,
     Generic(String),
     InvalidMemoryId,
+    InvalidConfiguration(String),
 }
 
 #[derive(Debug, Clone, Copy, CandidType, Deserialize, Eq, PartialEq, Hash)]
@@ -28,18 +29,19 @@ pub type LoggerAcl = HashSet<(Principal, LoggerPermission)>;
 
 /// Log settings to initialize the logger
 #[derive(Default, Debug, Clone, CandidType, Deserialize, PartialEq, Eq)]
-pub struct LogSettings {
+pub struct LogCanisterSettings {
     /// Enable logging to console (`ic::print` when running in IC)
-    pub enable_console: bool,
+    pub enable_console: Option<bool>,
     /// Number of records to be stored in the circular memory buffer.
     /// If None - storing records will be disable.
     /// If Some - should be power of two.
-    pub in_memory_records: usize,
+    pub in_memory_records: Option<usize>,
+    pub max_record_length: Option<usize>,
     /// Log configuration as combination of filters. By default the logger is OFF.
     /// Example of valid configurations:
     /// - info
     /// - debug,crate1::mod1=error,crate1::mod2,crate2=debug
-    pub log_filter: String,
+    pub log_filter: Option<String>,
 
-    pub acl: LoggerAcl,
+    pub acl: Option<LoggerAcl>,
 }

--- a/ic-log/src/did.rs
+++ b/ic-log/src/did.rs
@@ -1,0 +1,45 @@
+use std::collections::HashSet;
+
+use candid::CandidType;
+use ic_exports::ic_kit::Principal;
+use serde::Deserialize;
+
+#[derive(Debug, Copy, Clone, CandidType, Deserialize)]
+pub struct Pagination {
+    pub offset: usize,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone, CandidType, Deserialize, Eq, PartialEq)]
+pub enum LogCanisterError {
+    AlreadyInitialized,
+    NotAuthorized,
+    Generic(String),
+    InvalidMemoryId,
+}
+
+#[derive(Debug, Clone, Copy, CandidType, Deserialize, Eq, PartialEq, Hash)]
+pub enum LoggerPermission {
+    Read,
+    Configure,
+}
+
+pub type LoggerAcl = HashSet<(Principal, LoggerPermission)>;
+
+/// Log settings to initialize the logger
+#[derive(Default, Debug, Clone, CandidType, Deserialize, PartialEq, Eq)]
+pub struct LogSettings {
+    /// Enable logging to console (`ic::print` when running in IC)
+    pub enable_console: bool,
+    /// Number of records to be stored in the circular memory buffer.
+    /// If None - storing records will be disable.
+    /// If Some - should be power of two.
+    pub in_memory_records: usize,
+    /// Log configuration as combination of filters. By default the logger is OFF.
+    /// Example of valid configurations:
+    /// - info
+    /// - debug,crate1::mod1=error,crate1::mod2,crate2=debug
+    pub log_filter: String,
+
+    pub acl: LoggerAcl,
+}

--- a/ic-log/src/did.rs
+++ b/ic-log/src/did.rs
@@ -4,24 +4,36 @@ use candid::CandidType;
 use ic_exports::ic_kit::Principal;
 use serde::Deserialize;
 
+/// Specifies what to take from a long list of items.
 #[derive(Debug, Copy, Clone, CandidType, Deserialize)]
 pub struct Pagination {
+    /// First item id to get.
     pub offset: usize,
+    /// Max number of items to get.
     pub count: usize,
 }
 
+/// Error returned by the logger canister.
 #[derive(Debug, Clone, CandidType, Deserialize, Eq, PartialEq)]
 pub enum LogCanisterError {
+    /// An initialization was called for the logger, but it is already initialized.
     AlreadyInitialized,
+    /// The caller does not have permission to execute this method.
     NotAuthorized,
+    /// Something bad happened.
     Generic(String),
+    /// The given memory ID cannot be used to store logger configuration.
     InvalidMemoryId,
+    /// Error in the logger configuration.
     InvalidConfiguration(String),
 }
 
+/// Permission of a caller for logger canister operations.
 #[derive(Debug, Clone, Copy, CandidType, Deserialize, Eq, PartialEq, Hash)]
 pub enum LoggerPermission {
+    /// Allows the caller to get the logs.
     Read,
+    /// Allows the caller to get the logs and change the configuration of the canister.
     Configure,
 }
 
@@ -32,16 +44,31 @@ pub type LoggerAcl = HashSet<(Principal, LoggerPermission)>;
 pub struct LogCanisterSettings {
     /// Enable logging to console (`ic::print` when running in IC)
     pub enable_console: Option<bool>,
+
     /// Number of records to be stored in the circular memory buffer.
-    /// If None - storing records will be disable.
-    /// If Some - should be power of two.
+    ///
+    /// If set to 0, logging will be disabled.
+    ///
+    /// If `None`, default value will be used (`1024`).
     pub in_memory_records: Option<usize>,
+
+    /// Maximum length (in bytes) of a single log entry.
+    ///
+    /// If set to 0, the log will still add entries to the log, but they all will contain only an
+    /// empty string.
+    ///
+    /// If `None`, default value will be used (`1024`).
     pub max_record_length: Option<usize>,
-    /// Log configuration as combination of filters. By default the logger is OFF.
+
+    /// Log configuration as combination of filters. By default, the logger filter is set to `warn`.
+    ///
     /// Example of valid configurations:
     /// - info
     /// - debug,crate1::mod1=error,crate1::mod2,crate2=debug
     pub log_filter: Option<String>,
 
+    /// Access control list for the logs.
+    ///
+    /// Of set to `None`, the creator of the canister will be assigned `Configure` permission.
     pub acl: Option<LoggerAcl>,
 }

--- a/ic-log/src/lib.rs
+++ b/ic-log/src/lib.rs
@@ -8,6 +8,7 @@ pub mod canister;
 pub mod did;
 mod formatter;
 mod platform;
+mod settings;
 pub mod writer;
 
 use std::cell::RefCell;
@@ -15,8 +16,8 @@ use std::sync::Arc;
 
 use arc_swap::{ArcSwap, ArcSwapAny};
 use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};
+pub use settings::LogSettings;
 
-pub use self::did::LogSettings;
 use crate::formatter::Formatter;
 
 /// The logger.
@@ -342,7 +343,7 @@ pub fn init_log(settings: &LogSettings) -> Result<LoggerConfig, SetLoggerError> 
         builder = builder.add_writer(Box::new(ConsoleWriter {}));
     }
 
-    writer::InMemoryWriter::init_buffer(settings.in_memory_records);
+    writer::InMemoryWriter::init_buffer(settings.in_memory_records, settings.max_record_length);
     builder = builder.add_writer(Box::new(InMemoryWriter {}));
 
     builder.try_init()
@@ -365,6 +366,7 @@ mod tests {
         let config = init_log(&LogSettings {
             enable_console: true,
             in_memory_records: 0,
+            max_record_length: 1024,
             log_filter: "debug".to_string(),
             acl: Default::default(),
         })

--- a/ic-log/src/lib.rs
+++ b/ic-log/src/lib.rs
@@ -1,3 +1,9 @@
+//! Implementation of common Rust `log` usable by IC canisters. See the documentation for [`Logger`]
+//! about how to initialize and use `log`.
+//!
+//! This crate also provides a canister trait [`canister::LogCanister`] (use `canister` feature to
+//! enable), which simplifies adding logging configuration to your canister.
+
 use env_filter::Filter;
 use formatter::FormatFn;
 use writer::{ConsoleWriter, InMemoryWriter, Logs, MultiWriter, Writer};

--- a/ic-log/src/settings.rs
+++ b/ic-log/src/settings.rs
@@ -1,0 +1,59 @@
+use candid::{CandidType, Principal};
+use serde::Deserialize;
+
+use crate::did::{LogCanisterSettings, LoggerAcl, LoggerPermission};
+
+const DEFAULT_IN_MEMORY_RECORDS: usize = 1024;
+const DEFAULT_MAX_RECORD_LENGTH: usize = 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Deserialize)]
+pub struct LogSettings {
+    pub enable_console: bool,
+    pub in_memory_records: usize,
+    pub max_record_length: usize,
+    pub log_filter: String,
+    pub acl: LoggerAcl,
+}
+
+impl Default for LogSettings {
+    fn default() -> Self {
+        Self {
+            enable_console: true,
+            in_memory_records: DEFAULT_IN_MEMORY_RECORDS,
+            max_record_length: DEFAULT_MAX_RECORD_LENGTH,
+            log_filter: "debug".to_string(),
+            acl: Default::default(),
+        }
+    }
+}
+
+impl LogSettings {
+    pub fn from_did(settings: LogCanisterSettings, owner: Principal) -> Self {
+        let default = Self::default();
+        Self {
+            enable_console: settings.enable_console.unwrap_or(default.enable_console),
+            in_memory_records: settings
+                .in_memory_records
+                .unwrap_or(default.in_memory_records),
+            max_record_length: settings
+                .max_record_length
+                .unwrap_or(default.max_record_length),
+            log_filter: settings.log_filter.unwrap_or(default.log_filter),
+            acl: settings
+                .acl
+                .unwrap_or_else(|| [(owner, LoggerPermission::Configure)].into()),
+        }
+    }
+}
+
+impl From<LogSettings> for LogCanisterSettings {
+    fn from(value: LogSettings) -> Self {
+        Self {
+            enable_console: Some(value.enable_console),
+            in_memory_records: Some(value.in_memory_records),
+            max_record_length: Some(value.max_record_length),
+            log_filter: Some(value.log_filter),
+            acl: Some(value.acl),
+        }
+    }
+}

--- a/ic-log/src/writer.rs
+++ b/ic-log/src/writer.rs
@@ -51,8 +51,8 @@ type LogRecordsBuffer = AllocRingBuffer<String>;
 thread_local! {
     static LOG_RECORDS: RefCell<(usize, LogRecordsBuffer)> =
         RefCell::new((0, LogRecordsBuffer::new(INIT_LOG_CAPACITY)));
-    static IS_ENABLED: AtomicBool = AtomicBool::new(false);
-    static MAX_RECORD_LENGTH: AtomicUsize = AtomicUsize::new(0);
+    static IS_ENABLED: AtomicBool = const { AtomicBool::new(false) };
+    static MAX_RECORD_LENGTH: AtomicUsize = const { AtomicUsize::new(0) };
 }
 
 /// Writer that stores strings in a thread_local memory circular buffer.

--- a/ic-log/tests/in_memory_logger.rs
+++ b/ic-log/tests/in_memory_logger.rs
@@ -22,6 +22,7 @@ fn test_settings() -> LogSettings {
     LogSettings {
         enable_console: true,
         in_memory_records: 10,
+        max_record_length: 1024,
         log_filter: "info,ic_log=off".to_string(),
         acl: [
             (admin(), LoggerPermission::Configure),
@@ -35,7 +36,9 @@ fn test_state() -> LogState {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
         let mut state = LogState::default();
-        state.init(test_memory(), test_settings()).unwrap()
+        state
+            .init(admin(), test_memory(), test_settings().into())
+            .unwrap()
     });
 
     let settings = test_settings();

--- a/ic-log/tests/in_memory_logger.rs
+++ b/ic-log/tests/in_memory_logger.rs
@@ -1,0 +1,87 @@
+use std::sync::Once;
+
+use candid::Principal;
+use ic_log::canister::LogState;
+use ic_log::did::{LoggerPermission, Pagination};
+use ic_log::LogSettings;
+use ic_stable_structures::MemoryId;
+
+fn admin() -> Principal {
+    Principal::from_slice(&[1; 20])
+}
+
+fn reader() -> Principal {
+    Principal::from_slice(&[2; 20])
+}
+
+fn test_memory() -> MemoryId {
+    MemoryId::new(2)
+}
+
+fn test_settings() -> LogSettings {
+    LogSettings {
+        enable_console: true,
+        in_memory_records: 10,
+        log_filter: "info,ic_log=off".to_string(),
+        acl: [
+            (admin(), LoggerPermission::Configure),
+            (reader(), LoggerPermission::Read),
+        ]
+        .into(),
+    }
+}
+
+fn test_state() -> LogState {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let mut state = LogState::default();
+        state.init(test_memory(), test_settings()).unwrap()
+    });
+
+    let settings = test_settings();
+    let mut state = LogState::new(test_memory(), settings.acl);
+    state
+        .set_logger_filter(admin(), settings.log_filter)
+        .unwrap();
+    state
+}
+
+#[test]
+fn set_logger_filter_updates_filter() {
+    let mut state = test_state();
+    log::warn!("warn");
+    log::error!("error");
+
+    let logs = state
+        .get_logs(
+            admin(),
+            Pagination {
+                offset: 0,
+                count: 20,
+            },
+        )
+        .unwrap();
+    assert_eq!(logs.all_logs_count, 2);
+
+    state
+        .set_logger_filter(admin(), "info,ic_log=off,in_memory_logger=error".into())
+        .unwrap();
+
+    log::debug!("warn");
+    log::error!("error2");
+
+    let logs = state
+        .get_logs(
+            admin(),
+            Pagination {
+                offset: 0,
+                count: 20,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(logs.all_logs_count, 3);
+    assert_eq!(logs.logs.len(), 3);
+
+    assert!(logs.logs[2].log.contains(&"error2".to_string()))
+}

--- a/ic-stable-structures/src/structure/stable_storage/cell.rs
+++ b/ic-stable-structures/src/structure/stable_storage/cell.rs
@@ -8,8 +8,8 @@ pub struct StableCell<T: Storable, M: Memory>(cell::Cell<T, M>);
 
 impl<T: Storable, M: Memory> StableCell<T, M> {
     /// Create new storage for values with `T` type.
-    pub fn new(memory: M, value: T) -> Result<Self> {
-        Ok(Self(cell::Cell::init(memory, value)?))
+    pub fn new(memory: M, default_value: T) -> Result<Self> {
+        Ok(Self(cell::Cell::init(memory, default_value)?))
     }
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,8 +46,8 @@ build_ic_task_scheduler_dummy_scheduler_canister() {
 build_ic_log_test_canister() {
     echo "Building ic-log test canister"
 
-    cargo run -p ic-log --example log_canister --features export-api > $WASM_DIR/log_canister.did
-    cargo build -p ic-log --example log_canister --target wasm32-unknown-unknown --features export-api --release
+    cargo run -p ic-log --example log_canister --features canister > $WASM_DIR/log_canister.did
+    cargo build -p ic-log --example log_canister --target wasm32-unknown-unknown --features canister --release
     ic-wasm $WASM_DIR/examples/log_canister.wasm -o $WASM_DIR/log_canister.wasm shrink
 
 }


### PR DESCRIPTION
This PR add canister trait with the following features:
* logger access ACL checks
* logger configuration

The trait itself is hidden behind the `canister` feature, so any canister that wants to use the logger without importing all the API stuff can still do so.

Updates to the logger logic itself:
* `in_memory_records` settings is now not an option. If set to 0, in-memory logging will be disabled (same behavior as `None` value had before). This allows us to make this value configurable on-line.
* added `max_entry_length` setting to limit the possibility of DOS attacks by creating some very log logs
