### PR TITLE
Add `find_id` and `reschedule` methods to scheduler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 
 [workspace.dependencies]


### PR DESCRIPTION
This change is required to implement https://infinityswap.atlassian.net/browse/EPROD-961 . Change is backward compatible, so I update the patch number only.