### PR TITLE
Fix errors when using rust-analyzer with canister method attributes

### DIFF
--- a/ic-auction/src/state.rs
+++ b/ic-auction/src/state.rs
@@ -211,7 +211,7 @@ pub struct Controller<'a> {
     state: &'a mut AuctionState,
 }
 
-impl<'a> Authorized<Controller<'a>> {
+impl Authorized<Controller<'_>> {
     pub fn set_min_cycles(&mut self, min_cycles: Cycles) {
         self.auth.state.min_cycles = min_cycles;
     }

--- a/ic-canister/ic-canister-macros/src/api.rs
+++ b/ic-canister/ic-canister-macros/src/api.rs
@@ -516,10 +516,7 @@ fn store_candid_definitions(modes: &str, sig: &Signature) -> Result<(), syn::Err
     }
 
     if modes == "init" {
-        match &mut *INIT.lock().unwrap() {
-            Some(_) => return Err(Error::new_spanned(&sig.ident, "duplicate init method")),
-            ret @ None => *ret = Some(args),
-        }
+        *INIT.lock().unwrap() = Some(args);
         return Ok(());
     }
 
@@ -529,13 +526,6 @@ fn store_candid_definitions(modes: &str, sig: &Signature) -> Result<(), syn::Err
 
     // Insert method
     let mut map = METHODS.lock().unwrap();
-
-    if map.contains_key(&name) {
-        return Err(Error::new_spanned(
-            &name,
-            format!("duplicate method name {name}"),
-        ));
-    }
 
     let method = Method {
         args,

--- a/ic-log/src/formatter/humantime.rs
+++ b/ic-log/src/formatter/humantime.rs
@@ -28,7 +28,7 @@ impl fmt::Debug for Rfc3339Timestamp {
         /// A `Debug` wrapper for `Timestamp` that uses the `Display` implementation.
         struct TimestampValue<'a>(&'a Rfc3339Timestamp);
 
-        impl<'a> fmt::Debug for TimestampValue<'a> {
+        impl fmt::Debug for TimestampValue<'_> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 fmt::Display::fmt(&self.0, f)
             }

--- a/ic-log/src/formatter/mod.rs
+++ b/ic-log/src/formatter/mod.rs
@@ -151,7 +151,7 @@ struct DefaultFormat<'a> {
     suffix: &'a str,
 }
 
-impl<'a> DefaultFormat<'a> {
+impl DefaultFormat<'_> {
     fn write(mut self, record: &Record) -> io::Result<()> {
         self.write_timestamp()?;
         self.write_level(record)?;
@@ -250,7 +250,7 @@ impl<'a> DefaultFormat<'a> {
                     indent_count: usize,
                 }
 
-                impl<'a, 'b> Write for IndentWrapper<'a, 'b> {
+                impl Write for IndentWrapper<'_, '_> {
                     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
                         let mut first = true;
                         for chunk in buf.split(|&x| x == b'\n') {

--- a/ic-stable-structures/src/structure/stable_storage/multimap.rs
+++ b/ic-stable-structures/src/structure/stable_storage/multimap.rs
@@ -132,7 +132,7 @@ where
 // -----------------------------------------------------------------------------
 //     - Range Iterator impl -
 // -----------------------------------------------------------------------------
-impl<'a, K1, K2, V, M> Iterator for StableMultimapRangeIter<'a, K1, K2, V, M>
+impl<K1, K2, V, M> Iterator for StableMultimapRangeIter<'_, K1, K2, V, M>
 where
     K1: Storable + Ord + Clone,
     K2: Storable + Ord + Clone,
@@ -165,7 +165,7 @@ where
     }
 }
 
-impl<'a, K1, K2, V, M> Iterator for StableMultimapIter<'a, K1, K2, V, M>
+impl<K1, K2, V, M> Iterator for StableMultimapIter<'_, K1, K2, V, M>
 where
     K1: Storable + Ord + Clone,
     K2: Storable + Ord + Clone,


### PR DESCRIPTION
This commit removes checks by the `query`, `update` and `init` macroses that there are duplicate methods with the same name.

The reason this causes an issue is that in contrast with the rustc, rust-analyzer expands macroses using the same process all the time. This means that lazy_static storage for the macro is not dropped between invocations which produces the error. After this change, the new declaration of the method expanded by the rust-analyzer will just replace the old one.

This will change will also make the macros' implementation more correct for 2 reasons:

1. The checks we had are not reliable. They only check for duplication inside one crate, which in most cases is already coverred by the compiler when it check that there are no 2 methods with the same name.
2. Even if there are 2 method with the same name (in the same crate or across the crates), compiler will still report an error because these methods are exported by the WASM module with the same name. Such error method is more difficult to read then the ones we had, but it is more correct and works 100% of the time, which is more important.